### PR TITLE
added role badge

### DIFF
--- a/src/components/shared/DashboardCards.tsx
+++ b/src/components/shared/DashboardCards.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { useState, useMemo } from 'react';
 import InterviewDialog from './InterviewDialog';
+import RoleBadge from './RoleBadge';
 
 export default function DashboardCards() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -54,6 +55,7 @@ export default function DashboardCards() {
           "This frontend interview delves into the intricacies of JavaScript, React, and system design, providing a comprehensive assessment of a candidate's skills in these areas.",
         date: '2023-05-15',
         tags: ['Frontend', 'React', 'JavaScript'],
+        type: 'junior',
       },
       {
         id: 2,
@@ -63,6 +65,7 @@ export default function DashboardCards() {
         date: '2023-06-22',
         tags: ['Backend', 'AWS', 'Algorithms'],
         rating: 85,
+        type: 'mid',
       },
       {
         id: 3,
@@ -72,6 +75,7 @@ export default function DashboardCards() {
         date: '2023-07-10',
         tags: ['Fullstack', 'React', '.NET'],
         rating: 78,
+        type: 'senior',
       },
       {
         id: 4,
@@ -81,6 +85,7 @@ export default function DashboardCards() {
         date: '2023-08-05',
         tags: ['System Design', 'Scalability'],
         rating: 89,
+        type: 'senior',
       },
       {
         id: 5,
@@ -89,6 +94,7 @@ export default function DashboardCards() {
           'UI engineering interview with focus on responsive design and performance optimization.',
         date: '2023-09-12',
         tags: ['UI', 'Frontend', 'Performance'],
+        type: 'junior',
       },
       {
         id: 6,
@@ -97,6 +103,7 @@ export default function DashboardCards() {
           'Backend interview covering distributed systems and real-time processing.',
         date: '2023-10-08',
         tags: ['Backend', 'Distributed Systems'],
+        type: 'mid',
       },
     ],
     []
@@ -207,7 +214,7 @@ export default function DashboardCards() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredInterviews.map((interview) => (
-          <Card key={interview.id}>
+          <Card key={interview.id} className="relative">
             <CardHeader>
               <CardTitle className="flex flex-row items-center gap-2 font-normal text-muted-foreground">
                 <div className="h-8 w-8 flex items-center justify-center bg-primary text-primary-foreground rounded-full">
@@ -244,6 +251,9 @@ export default function DashboardCards() {
                 View
               </Button>
             </CardFooter>
+            <div className="absolute -top-0.5 right-0">
+              <RoleBadge type={interview.type as 'junior' | 'mid' | 'senior'} />
+            </div>
           </Card>
         ))}
       </div>

--- a/src/components/shared/InterviewDialog.tsx
+++ b/src/components/shared/InterviewDialog.tsx
@@ -24,6 +24,7 @@ import {
   EllipsisVerticalIcon,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
+import RoleBadge from './RoleBadge';
 
 interface InterviewDialogProps {
   interview: any;
@@ -59,7 +60,10 @@ export default function InterviewDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="w-[600px] ">
         <DialogHeader className="relative">
-          <DialogTitle>{interview.title}</DialogTitle>
+          <DialogTitle className="flex flex-row gap-2 items-center">
+            {interview.title}
+            <RoleBadge type={interview.type as 'junior' | 'mid' | 'senior'} />
+          </DialogTitle>
           <div className="flex flex-row gap-4 text-sm">
             <div className="flex flex-row items-center gap-2 ">
               <CalendarIcon className="h-4 w-4" />

--- a/src/components/shared/ProfileCards.tsx
+++ b/src/components/shared/ProfileCards.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { useState, useMemo } from 'react';
 import InterviewDialog from './InterviewDialog';
+import RoleBadge from './RoleBadge';
 
 export default function ProfileCards() {
   const { isLoading } = useAuth();
@@ -43,6 +44,7 @@ export default function ProfileCards() {
 
         tags: ['Frontend', 'React', 'JavaScript'],
         rating: 82,
+        type: 'junior',
       },
       {
         id: 2,
@@ -52,6 +54,7 @@ export default function ProfileCards() {
         date: '2023-06-22',
         tags: ['Backend', 'AWS', 'Algorithms'],
         rating: 85,
+        type: 'mid',
       },
       {
         id: 3,
@@ -61,6 +64,7 @@ export default function ProfileCards() {
         date: '2023-07-10',
         tags: ['Fullstack', 'React', '.NET'],
         rating: 78,
+        type: 'senior',
       },
       {
         id: 4,
@@ -70,6 +74,7 @@ export default function ProfileCards() {
         date: '2023-08-05',
         tags: ['System Design', 'Scalability'],
         rating: 89,
+        type: 'senior',
       },
       {
         id: 5,
@@ -79,6 +84,7 @@ export default function ProfileCards() {
         date: '2023-09-12',
         tags: ['UI', 'Frontend', 'Performance'],
         rating: 72,
+        type: 'junior',
       },
       {
         id: 6,
@@ -88,6 +94,7 @@ export default function ProfileCards() {
         date: '2023-10-08',
         tags: ['Backend', 'Distributed Systems'],
         rating: 81,
+        type: 'mid',
       },
     ],
     []
@@ -140,7 +147,7 @@ export default function ProfileCards() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {filteredInterviews.map((interview) => (
-          <Card key={interview.id}>
+          <Card key={interview.id} className="relative">
             <CardHeader>
               <CardTitle className="flex flex-row items-center gap-2 font-normal text-muted-foreground">
                 <div className="h-8 w-8 flex items-center justify-center bg-primary text-primary-foreground rounded-full">
@@ -176,6 +183,9 @@ export default function ProfileCards() {
                 View
               </Button>
             </CardFooter>
+            <div className="absolute -top-0.5 right-0">
+              <RoleBadge type={interview.type as 'junior' | 'mid' | 'senior'} />
+            </div>
           </Card>
         ))}
       </div>

--- a/src/components/shared/RoleBadge.tsx
+++ b/src/components/shared/RoleBadge.tsx
@@ -1,0 +1,34 @@
+import { Badge } from '@/components/ui/badge';
+
+const roleDetails = {
+  junior: {
+    bg: 'bg-emerald-600/10 dark:bg-emerald-600/20 hover:bg-emerald-600/10',
+    text: 'text-emerald-500',
+    dot: 'bg-emerald-500',
+    label: 'Junior',
+  },
+  mid: {
+    bg: 'bg-amber-600/10 dark:bg-amber-600/20 hover:bg-amber-600/10',
+    text: 'text-amber-500',
+    dot: 'bg-amber-500',
+    label: 'Mid',
+  },
+  senior: {
+    bg: 'bg-red-600/10 dark:bg-red-600/20 hover:bg-red-600/10',
+    text: 'text-red-500',
+    dot: 'bg-red-500',
+    label: 'Senior',
+  },
+};
+
+const RoleBadge = ({ type }: { type: 'senior' | 'mid' | 'junior' }) => {
+  const { bg, text, dot, label } = roleDetails[type];
+
+  return (
+    <Badge className={`${bg} ${text} shadow-none rounded-full gap-2`}>
+      <div className={`h-1.5 w-1.5 rounded-full ${dot}`} /> {label}
+    </Badge>
+  );
+};
+
+export default RoleBadge;


### PR DESCRIPTION
# Role Badge Component Implementation

Added a new reusable badge component to visually distinguish between different job experience levels:

- Created color-coded badges for Junior, Mid, and Senior roles
- Each badge has a unique color theme that helps users quickly identify role levels
- Junior roles appear in green, Mid-level in amber, and Senior in red
- Added a small colored dot next to each label for enhanced visual distinction
- Designed with a clean, rounded appearance that works in both light and dark modes

This component makes it easier for users to quickly scan and identify role levels throughout the application with consistent styling.
